### PR TITLE
Move public implementation of `synchronized` back to module `:common-core`

### DIFF
--- a/library/common-api/api/common-api.api
+++ b/library/common-api/api/common-api.api
@@ -56,11 +56,3 @@ public abstract class io/matthewnelson/kmp/tor/common/api/TorApi {
 	protected abstract fun torMainProtected ([Ljava/lang/String;)V
 }
 
-public final class io/matthewnelson/kmp/tor/common/api/internal/SynchronizedCommon {
-	public static final fun synchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
-public final class io/matthewnelson/kmp/tor/common/api/internal/SynchronizedJvm {
-	public static final fun synchronizedImpl (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-

--- a/library/common-api/api/common-api.klib.api
+++ b/library/common-api/api/common-api.klib.api
@@ -1,6 +1,5 @@
 // Klib ABI Dump
 // Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
-// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -69,9 +68,3 @@ final class io.matthewnelson.kmp.tor.common.api/GeoipFiles { // io.matthewnelson
     final fun hashCode(): kotlin/Int // io.matthewnelson.kmp.tor.common.api/GeoipFiles.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // io.matthewnelson.kmp.tor.common.api/GeoipFiles.toString|toString(){}[0]
 }
-
-// Targets: [apple]
-final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.api.internal/synchronized(kotlinx.atomicfu.locks/SynchronizedObject, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.api.internal/synchronized|synchronized(kotlinx.atomicfu.locks.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
-
-// Targets: [apple]
-final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.api.internal/synchronizedImpl(kotlinx.atomicfu.locks/SynchronizedObject, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.api.internal/synchronizedImpl|synchronizedImpl(kotlinx.atomicfu.locks.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]

--- a/library/common-api/api/common-api.klib.api
+++ b/library/common-api/api/common-api.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
 // Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
-// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -70,14 +70,8 @@ final class io.matthewnelson.kmp.tor.common.api/GeoipFiles { // io.matthewnelson
     final fun toString(): kotlin/String // io.matthewnelson.kmp.tor.common.api/GeoipFiles.toString|toString(){}[0]
 }
 
-// Targets: [native]
+// Targets: [apple]
 final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.api.internal/synchronized(kotlinx.atomicfu.locks/SynchronizedObject, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.api.internal/synchronized|synchronized(kotlinx.atomicfu.locks.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
 
-// Targets: [native]
+// Targets: [apple]
 final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.api.internal/synchronizedImpl(kotlinx.atomicfu.locks/SynchronizedObject, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.api.internal/synchronizedImpl|synchronizedImpl(kotlinx.atomicfu.locks.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
-
-// Targets: [js]
-final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.api.internal/synchronized(kotlin/Any, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.api.internal/synchronized|synchronized(kotlin.Any;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
-
-// Targets: [js]
-final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.api.internal/synchronizedImpl(kotlin/Any, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.api.internal/synchronizedImpl|synchronizedImpl(kotlin.Any;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]

--- a/library/common-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/api/TorApi.kt
+++ b/library/common-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/api/TorApi.kt
@@ -28,16 +28,14 @@ public constructor() {
     @get:JvmName("isRunning")
     public val isRunning: Boolean get() = _isRunning
 
-    @OptIn(InternalKmpTorApi::class)
-    private val lock = SynchronizedObject()
     @Volatile
     private var _isRunning: Boolean = false
+    private val lock = SynchronizedObject()
 
     @Throws(IllegalArgumentException::class, IllegalStateException::class, IOException::class)
     public fun torMain(args: List<String>) {
         check(!_isRunning) { "tor is running" }
 
-        @OptIn(InternalKmpTorApi::class)
         val argsArray = synchronized(lock) {
             check(!_isRunning) { "tor is running" }
 

--- a/library/common-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/Singleton.kt
+++ b/library/common-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/Singleton.kt
@@ -15,18 +15,15 @@
  **/
 package io.matthewnelson.kmp.tor.common.api.internal
 
-import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import kotlin.concurrent.Volatile
 
 internal open class Singleton<T: Any> internal constructor() {
 
     @Volatile
     private var instance: T? = null
-    @OptIn(InternalKmpTorApi::class)
     private val lock = SynchronizedObject()
 
     internal fun getOrCreate(create: () -> T): T {
-        @OptIn(InternalKmpTorApi::class)
         return instance ?: synchronized(lock) {
             instance ?: create().also { instance = it }
         }

--- a/library/common-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/SynchronizedCommon.kt
+++ b/library/common-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/SynchronizedCommon.kt
@@ -18,25 +18,20 @@
 
 package io.matthewnelson.kmp.tor.common.api.internal
 
-import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.jvm.JvmName
 
-@InternalKmpTorApi
-public expect open class SynchronizedObject()
+internal expect open class SynchronizedObject()
 
-@PublishedApi
-@OptIn(InternalKmpTorApi::class)
 internal expect inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
     block: () -> T
 ): T
 
-@InternalKmpTorApi
 @OptIn(ExperimentalContracts::class)
-public inline fun <T: Any?> synchronized(
+internal inline fun <T: Any?> synchronized(
     lock: SynchronizedObject,
     block: () -> T
 ): T {

--- a/library/common-api/src/jvmMain/java9/module-info.java
+++ b/library/common-api/src/jvmMain/java9/module-info.java
@@ -3,5 +3,4 @@ module io.matthewnelson.kmp.tor.common.api {
     requires transitive io.matthewnelson.kmp.file;
 
     exports io.matthewnelson.kmp.tor.common.api;
-    exports io.matthewnelson.kmp.tor.common.api.internal;
 }

--- a/library/common-api/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/-SynchronizedJvm.kt
+++ b/library/common-api/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/-SynchronizedJvm.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:JvmName("SynchronizedJvm")
 @file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
 package io.matthewnelson.kmp.tor.common.api.internal
@@ -22,5 +23,5 @@ internal actual typealias SynchronizedObject = Any
 
 internal actual inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
-    block: () -> T,
-): T = block()
+    block: () -> T
+): T = kotlin.synchronized(lock, block)

--- a/library/common-api/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/SynchronizedNative.kt
+++ b/library/common-api/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/common/api/internal/SynchronizedNative.kt
@@ -17,14 +17,11 @@
 
 package io.matthewnelson.kmp.tor.common.api.internal
 
-import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import kotlinx.atomicfu.locks.withLock as _withLock
 
-@InternalKmpTorApi
-public actual typealias SynchronizedObject = kotlinx.atomicfu.locks.SynchronizedObject
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias SynchronizedObject = kotlinx.atomicfu.locks.SynchronizedObject
 
-@PublishedApi
-@OptIn(InternalKmpTorApi::class)
 internal actual inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
     block: () -> T

--- a/library/common-core/api/common-core.api
+++ b/library/common-core/api/common-core.api
@@ -140,3 +140,11 @@ public final class io/matthewnelson/kmp/tor/common/core/Resource$Config$Companio
 	public final fun create (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/tor/common/core/Resource$Config;
 }
 
+public final class io/matthewnelson/kmp/tor/common/core/SynchronizedCommon {
+	public static final fun synchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class io/matthewnelson/kmp/tor/common/core/SynchronizedJvm {
+	public static final fun synchronizedImpl (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+

--- a/library/common-core/api/common-core.klib.api
+++ b/library/common-core/api/common-core.klib.api
@@ -109,6 +109,12 @@ abstract class io.matthewnelson.kmp.tor.common.core/NativeResource { // io.matth
     final object Companion // io.matthewnelson.kmp.tor.common.core/NativeResource.Companion|null[0]
 }
 
+// Targets: [native]
+final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.core/synchronized(kotlinx.atomicfu.locks/SynchronizedObject, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.core/synchronized|synchronized(kotlinx.atomicfu.locks.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
+
+// Targets: [native]
+final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.core/synchronizedImpl(kotlinx.atomicfu.locks/SynchronizedObject, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.core/synchronizedImpl|synchronizedImpl(kotlinx.atomicfu.locks.SynchronizedObject;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
+
 // Targets: [js]
 final class io.matthewnelson.kmp.tor.common.core/OSInfo { // io.matthewnelson.kmp.tor.common.core/OSInfo|null[0]
     final val osArch // io.matthewnelson.kmp.tor.common.core/OSInfo.osArch|{}osArch[0]
@@ -187,3 +193,9 @@ sealed class io.matthewnelson.kmp.tor.common.core/OSHost { // io.matthewnelson.k
 
     final object Windows : io.matthewnelson.kmp.tor.common.core/OSHost // io.matthewnelson.kmp.tor.common.core/OSHost.Windows|null[0]
 }
+
+// Targets: [js]
+final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.core/synchronized(kotlin/Any, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.core/synchronized|synchronized(kotlin.Any;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
+
+// Targets: [js]
+final inline fun <#A: kotlin/Any?> io.matthewnelson.kmp.tor.common.core/synchronizedImpl(kotlin/Any, kotlin/Function0<#A>): #A // io.matthewnelson.kmp.tor.common.core/synchronizedImpl|synchronizedImpl(kotlin.Any;kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]

--- a/library/common-core/build.gradle.kts
+++ b/library/common-core/build.gradle.kts
@@ -65,6 +65,7 @@ kmpConfiguration {
                         implementation(libs.encoding.base16)
                         implementation(libs.encoding.base64)
                         implementation(libs.kotlincrypto.hash.sha2)
+                        implementation(libs.kotlinx.atomicfu)
                     }
                 }
 

--- a/library/common-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedCommon.kt
+++ b/library/common-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedCommon.kt
@@ -13,19 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:JvmName("SynchronizedJvm")
+@file:JvmName("SynchronizedCommon")
 @file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
-package io.matthewnelson.kmp.tor.common.api.internal
+package io.matthewnelson.kmp.tor.common.core
 
 import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.jvm.JvmName
 
 @InternalKmpTorApi
-public actual typealias SynchronizedObject = Any
+public expect open class SynchronizedObject()
 
 @PublishedApi
 @OptIn(InternalKmpTorApi::class)
-internal actual inline fun <T: Any?> synchronizedImpl(
+internal expect inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
     block: () -> T
-): T = kotlin.synchronized(lock, block)
+): T
+
+@InternalKmpTorApi
+@OptIn(ExperimentalContracts::class)
+public inline fun <T: Any?> synchronized(
+    lock: SynchronizedObject,
+    block: () -> T
+): T {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+
+    return synchronizedImpl(lock, block)
+}

--- a/library/common-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedJs.kt
+++ b/library/common-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedJs.kt
@@ -15,11 +15,15 @@
  **/
 @file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
-package io.matthewnelson.kmp.tor.common.api.internal
+package io.matthewnelson.kmp.tor.common.core
 
-@Suppress("ACTUAL_WITHOUT_EXPECT")
-internal actual typealias SynchronizedObject = Any
+import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 
+@InternalKmpTorApi
+public actual typealias SynchronizedObject = Any
+
+@PublishedApi
+@OptIn(InternalKmpTorApi::class)
 internal actual inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
     block: () -> T,

--- a/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedJvm.kt
+++ b/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedJvm.kt
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:JvmName("SynchronizedJvm")
 @file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
-package io.matthewnelson.kmp.tor.common.api.internal
+package io.matthewnelson.kmp.tor.common.core
 
-@Suppress("ACTUAL_WITHOUT_EXPECT")
-internal actual typealias SynchronizedObject = Any
+import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 
+@InternalKmpTorApi
+public actual typealias SynchronizedObject = Any
+
+@PublishedApi
+@OptIn(InternalKmpTorApi::class)
 internal actual inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
-    block: () -> T,
-): T = block()
+    block: () -> T
+): T = kotlin.synchronized(lock, block)

--- a/library/common-core/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedNative.kt
+++ b/library/common-core/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/common/core/SynchronizedNative.kt
@@ -15,12 +15,17 @@
  **/
 @file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
-package io.matthewnelson.kmp.tor.common.api.internal
+package io.matthewnelson.kmp.tor.common.core
 
-@Suppress("ACTUAL_WITHOUT_EXPECT")
-internal actual typealias SynchronizedObject = Any
+import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
+import kotlinx.atomicfu.locks.withLock as _withLock
 
+@InternalKmpTorApi
+public actual typealias SynchronizedObject = kotlinx.atomicfu.locks.SynchronizedObject
+
+@PublishedApi
+@OptIn(InternalKmpTorApi::class)
 internal actual inline fun <T: Any?> synchronizedImpl(
     lock: SynchronizedObject,
-    block: () -> T,
-): T = block()
+    block: () -> T
+): T = lock._withLock(block)


### PR DESCRIPTION
Closes #58 