### PR TITLE
Add check for `libandroid.so` presence when determining linux flavor for `OSInfo.osHost`

### DIFF
--- a/library/common-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/common/core/OSInfo.kt
+++ b/library/common-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/common/core/OSInfo.kt
@@ -64,6 +64,7 @@ public actual class OSInfo private constructor(
             "freebsd" -> OSHost.FreeBSD
             "android" -> OSHost.Linux.Android
             "linux" -> when {
+                hasLibAndroid() -> OSHost.Linux.Android
                 isLinuxMusl() -> OSHost.Linux.Musl
                 else -> OSHost.Linux.Libc
             }
@@ -79,6 +80,13 @@ public actual class OSInfo private constructor(
         resolveMachineArch()?.let { return@lazy it }
 
         OSArch.Unsupported(archNameLC)
+    }
+
+    private fun hasLibAndroid(): Boolean = try {
+        "/system/lib/libandroid.so".toFile().exists()
+        || "/system/lib64/libandroid.so".toFile().exists()
+    } catch (_: Throwable) {
+        false
     }
 
     private fun isLinuxMusl(): Boolean {

--- a/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/OSInfo.kt
+++ b/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/OSInfo.kt
@@ -20,7 +20,6 @@ package io.matthewnelson.kmp.tor.common.core
 
 import io.matthewnelson.kmp.file.ANDROID
 import io.matthewnelson.kmp.file.File
-import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.toFile
 import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.core.internal.ARCH_MAP
@@ -79,7 +78,7 @@ public actual class OSInfo private constructor(
             hostNameLC.contains("darwin") -> OSHost.MacOS
             hostNameLC.contains("freebsd") -> OSHost.FreeBSD
             hostNameLC.contains("linux") -> when {
-                isAndroidRuntime() -> OSHost.Linux.Android
+                ANDROID.SDK_INT != null -> OSHost.Linux.Android
                 isAndroidTermux() -> OSHost.Linux.Android
                 isLinuxMusl() -> OSHost.Linux.Musl
                 else -> OSHost.Linux.Libc
@@ -101,8 +100,6 @@ public actual class OSInfo private constructor(
 
         OSArch.Unsupported(archName.replace("\\W", "").lowercase(Locale.US))
     }
-
-    public fun isAndroidRuntime(): Boolean = ANDROID.SDK_INT != null
 
     private fun isAndroidTermux(): Boolean = try {
         process.runAndWait(listOf("uname", "-o"))
@@ -247,4 +244,13 @@ public actual class OSInfo private constructor(
         // Unsupported
         return null
     }
+
+    @Deprecated(
+        message = "Ambiguity in function name.",
+        replaceWith = ReplaceWith(
+            "ANDROID.SDK_INT != null",
+            "io.matthewnelson.kmp.file.ANDROID",
+        ),
+    )
+    public fun isAndroidRuntime(): Boolean = ANDROID.SDK_INT != null
 }

--- a/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/OSInfo.kt
+++ b/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/OSInfo.kt
@@ -79,6 +79,7 @@ public actual class OSInfo private constructor(
             hostNameLC.contains("freebsd") -> OSHost.FreeBSD
             hostNameLC.contains("linux") -> when {
                 ANDROID.SDK_INT != null -> OSHost.Linux.Android
+                hasLibAndroid() -> OSHost.Linux.Android
                 isAndroidTermux() -> OSHost.Linux.Android
                 isLinuxMusl() -> OSHost.Linux.Musl
                 else -> OSHost.Linux.Libc
@@ -105,6 +106,13 @@ public actual class OSInfo private constructor(
         process.runAndWait(listOf("uname", "-o"))
             .contains("android", ignoreCase = true)
     } catch (_: Throwable) {
+        false
+    }
+
+    private fun hasLibAndroid(): Boolean = try {
+        "/system/lib/libandroid.so".toFile().exists()
+        || "/system/lib64/libandroid.so".toFile().exists()
+    } catch (_: SecurityException) {
         false
     }
 


### PR DESCRIPTION
Closes #98 

Also deprecates `OSInfo.isAndroidRuntime`