### PR TITLE
Add check for 32-bit Linux when hardware reports `aarch64`

### DIFF
--- a/library/common-core/api/common-core.api
+++ b/library/common-core/api/common-core.api
@@ -85,7 +85,7 @@ public final class io/matthewnelson/kmp/tor/common/core/OSHost$Windows : io/matt
 public final class io/matthewnelson/kmp/tor/common/core/OSInfo {
 	public static final field Companion Lio/matthewnelson/kmp/tor/common/core/OSInfo$Companion;
 	public static final field INSTANCE Lio/matthewnelson/kmp/tor/common/core/OSInfo;
-	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/common/core/internal/ProcessRunner;Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/common/core/internal/ProcessRunner;Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun isAndroidRuntime ()Z
 	public final fun osArch ()Lio/matthewnelson/kmp/tor/common/core/OSArch;
 	public final fun osHost ()Lio/matthewnelson/kmp/tor/common/core/OSHost;

--- a/library/common-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/_ModuleChildProcess.kt
+++ b/library/common-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/_ModuleChildProcess.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.common.core.internal.node
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.toIOException
+import io.matthewnelson.kmp.tor.common.core.internal.ProcessRunner
+
+internal actual external interface ModuleChildProcess {
+    fun spawnSync(command: String, args: Array<String>, options: dynamic): dynamic
+}
+
+internal actual fun ModuleChildProcess.processRunner(): ProcessRunner = ProcessRunner { commands, duration ->
+    val command = commands.firstOrNull() ?: throw IOException("No commands specified")
+    val args = Array(commands.size - 1) { i -> commands[i + 1] }
+    val options = js("({})")
+    options["stdio"] = arrayOf("ignore", "pipe", "ignore")
+    options["timeout"] = duration.inWholeMilliseconds.coerceIn(250L, 1_000L).toInt()
+    options["encoding"] = "utf8"
+    options["windowsHide"] = true
+
+    val ret = try {
+        spawnSync(command, args, options)
+    } catch (t: Throwable) {
+        throw t.toIOException()
+    }
+
+    val status = (ret["status"] as? Number)?.toInt() ?: throw IOException("status == null")
+    if (status != 0) throw IOException("status[$status] != 0")
+    (ret["stdout"] as? String)?.trim() ?: ""
+}

--- a/library/common-core/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunner.kt
+++ b/library/common-core/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunner.kt
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.common.core.internal.node
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
-internal actual fun nodeModuleChildProcess(): ModuleChildProcess = js("eval('require')('child_process')")
-internal actual fun nodeModuleFs(): ModuleFs = js("eval('require')('fs')")
-internal actual fun nodeModuleOs(): ModuleOs = js("eval('require')('os')")
-internal actual fun nodeModuleZlib(): ModuleZlib = js("eval('require')('zlib')")
+package io.matthewnelson.kmp.tor.common.core.internal
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.InterruptedException
+import kotlin.time.Duration
+
+internal actual fun interface ProcessRunner {
+    @Throws(IOException::class, InterruptedException::class)
+    actual fun runAndWait(commands: List<String>, timeout: Duration): String
+}

--- a/library/common-core/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/ModuleChildProcess.kt
+++ b/library/common-core/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/ModuleChildProcess.kt
@@ -13,9 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package io.matthewnelson.kmp.tor.common.core.internal.node
 
-internal actual fun nodeModuleChildProcess(): ModuleChildProcess = js("eval('require')('child_process')")
-internal actual fun nodeModuleFs(): ModuleFs = js("eval('require')('fs')")
-internal actual fun nodeModuleOs(): ModuleOs = js("eval('require')('os')")
-internal actual fun nodeModuleZlib(): ModuleZlib = js("eval('require')('zlib')")
+import io.matthewnelson.kmp.tor.common.core.internal.ProcessRunner
+
+internal expect interface ModuleChildProcess {
+//    fun spawnSync(command: String, args: Array<String>, options: JsObject): JsObject
+}
+
+internal expect fun ModuleChildProcess.processRunner(): ProcessRunner

--- a/library/common-core/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/Modules.kt
+++ b/library/common-core/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/Modules.kt
@@ -17,9 +17,16 @@ package io.matthewnelson.kmp.tor.common.core.internal.node
 
 import io.matthewnelson.kmp.file.SysFsInfo
 
+internal expect fun nodeModuleChildProcess(): ModuleChildProcess
 internal expect fun nodeModuleFs(): ModuleFs
 internal expect fun nodeModuleOs(): ModuleOs
 internal expect fun nodeModuleZlib(): ModuleZlib
+
+@get:Throws(UnsupportedOperationException::class)
+internal val node_child_process: ModuleChildProcess by lazy {
+    requireNodeJs { "child_process" }
+    nodeModuleChildProcess()
+}
 
 @get:Throws(UnsupportedOperationException::class)
 internal val node_fs: ModuleFs by lazy {

--- a/library/common-core/src/jsWasmJsTest/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunnerUnitTest.kt
+++ b/library/common-core/src/jsWasmJsTest/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunnerUnitTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.common.core.internal
+
+import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.common.core.OSHost
+import io.matthewnelson.kmp.tor.common.core.OSInfo
+import io.matthewnelson.kmp.tor.common.core.internal.node.node_child_process
+import io.matthewnelson.kmp.tor.common.core.internal.node.processRunner
+import kotlin.test.Test
+import kotlin.test.fail
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(InternalKmpTorApi::class)
+class ProcessRunnerUnitTest {
+
+    @Test
+    fun givenLinuxHost_whenCheckBitness_thenReturns32Or64() {
+        if (OSInfo.INSTANCE.osHost !is OSHost.Linux) {
+            println("Skipping...")
+            return
+        }
+
+        val out = node_child_process
+            .processRunner()
+            .runAndWait(listOf("file", "/bin/bash"), 250.milliseconds)
+
+        if (!out.contains("ELF")) {
+            fail("command 'file /bin/bash' result does not contain ELF...\n\n$out")
+        }
+        if (!out.contains("-bit")) {
+            fail("command 'file /bin/bash' result does not contain -bit...\n\n$out")
+        }
+
+        println(out)
+    }
+}

--- a/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunner.kt
+++ b/library/common-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunner.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package io.matthewnelson.kmp.tor.common.core.internal
 
 import io.matthewnelson.kmp.file.ANDROID
@@ -22,10 +24,10 @@ import kotlin.math.min
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-internal fun interface ProcessRunner {
+internal actual fun interface ProcessRunner {
 
     @Throws(IOException::class, InterruptedException::class)
-    fun runAndWait(commands: List<String>, timeout: Duration): String
+    actual fun runAndWait(commands: List<String>, timeout: Duration): String
 
     object Default: ProcessRunner {
 

--- a/library/common-core/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/-NonNativePlatform.kt
+++ b/library/common-core/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/-NonNativePlatform.kt
@@ -46,9 +46,6 @@ internal val ARCH_MAP: Map<String, OSArch> by lazy {
         Pair("ppc64el", OSArch.Ppc64),
         Pair("ppc64le", OSArch.Ppc64),
 
-        Pair("aarch64", OSArch.Aarch64),
-        Pair("arm64", OSArch.Aarch64),
-
         Pair("riscv64", OSArch.Riscv64),
     )
 }

--- a/library/common-core/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunner.kt
+++ b/library/common-core/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/ProcessRunner.kt
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.common.core.internal.node
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
-internal actual fun nodeModuleChildProcess(): ModuleChildProcess = js("eval('require')('child_process')")
-internal actual fun nodeModuleFs(): ModuleFs = js("eval('require')('fs')")
-internal actual fun nodeModuleOs(): ModuleOs = js("eval('require')('os')")
-internal actual fun nodeModuleZlib(): ModuleZlib = js("eval('require')('zlib')")
+package io.matthewnelson.kmp.tor.common.core.internal
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.InterruptedException
+import kotlin.time.Duration
+
+internal expect fun interface ProcessRunner {
+    @Throws(IOException::class, InterruptedException::class)
+    fun runAndWait(commands: List<String>, timeout: Duration): String
+}

--- a/library/common-core/src/wasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/_ModuleChildProcess.kt
+++ b/library/common-core/src/wasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/_ModuleChildProcess.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "NOTHING_TO_INLINE")
+
+package io.matthewnelson.kmp.tor.common.core.internal.node
+
+import io.matthewnelson.kmp.file.DelicateFileApi
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.jsExternTryCatch
+import io.matthewnelson.kmp.file.toIOException
+import io.matthewnelson.kmp.tor.common.core.internal.ProcessRunner
+import io.matthewnelson.kmp.tor.common.core.internal.js.JsObject
+
+internal actual external interface ModuleChildProcess {
+    fun spawnSync(command: String, args: JsAny, options: JsObject): JsObject
+}
+
+internal actual fun ModuleChildProcess.processRunner(): ProcessRunner = ProcessRunner { commands, duration ->
+    val command = commands.firstOrNull() ?: throw IOException("No commands specified")
+
+    val args = JsStringArray.of(commands.size - 1)
+    for (i in 1 until commands.size) {
+        args.set(index = i - 1, commands[i])
+    }
+
+    val options = processOptions(
+        stdio = JsStringArray.of(3).apply {
+            set(0, "ignore")
+            set(1, "pipe")
+            set(2, "ignore")
+        },
+        timeout = duration.inWholeMilliseconds.coerceIn(250L, 1_000L).toInt(),
+        encoding = "utf8",
+        windowsHide = true,
+    )
+
+    val ret = try {
+        @OptIn(DelicateFileApi::class)
+        jsExternTryCatch { spawnSync(command, args, options) }
+    } catch (t: Throwable) {
+        throw t.toIOException()
+    }
+
+    val status = processStatus(ret) ?: throw IOException("status == null")
+    if (status != 0) throw IOException("status[$status] != 0")
+    processStdout(ret)?.trim() ?: ""
+}
+
+@JsName("Array")
+@Suppress("UNUSED")
+private external class JsStringArray: JsAny {
+    companion object {
+        fun of(size: Int): JsStringArray
+    }
+}
+
+private inline operator fun JsStringArray.set(index: Int, value: String) = jsArraySet(this, index, value)
+
+@Suppress("UNUSED")
+private fun jsArraySet(array: JsStringArray, index: Int, value: String) {
+    js("array[index] = value")
+}
+
+@Suppress("UNUSED")
+private fun processOptions(
+    stdio: JsStringArray,
+    timeout: Int,
+    encoding: String,
+    windowsHide: Boolean,
+): JsObject = js("({ stdio: stdio, timeout: timeout, encoding: encoding, windowsHide: windowsHide })")
+
+@Suppress("RedundantNullableReturnType")
+private fun processStatus(ret: JsObject): Int? = js("ret['status']")
+
+@Suppress("RedundantNullableReturnType")
+private fun processStdout(ret: JsObject): String? = js("ret['stdout']")

--- a/library/common-core/src/wasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/_Modules.kt
+++ b/library/common-core/src/wasmJsMain/kotlin/io/matthewnelson/kmp/tor/common/core/internal/node/_Modules.kt
@@ -15,6 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor.common.core.internal.node
 
+internal actual fun nodeModuleChildProcess(): ModuleChildProcess = js("eval('require')('child_process')")
 internal actual fun nodeModuleFs(): ModuleFs = js("eval('require')('fs')")
 internal actual fun nodeModuleOs(): ModuleOs = js("eval('require')('os')")
 internal actual fun nodeModuleZlib(): ModuleZlib = js("eval('require')('zlib')")

--- a/test-info/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/test/info/Main.kt
+++ b/test-info/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/common/test/info/Main.kt
@@ -21,6 +21,8 @@ import io.matthewnelson.kmp.tor.common.core.OSHost
 import io.matthewnelson.kmp.tor.common.core.OSInfo
 
 internal fun main(array: Array<out String>) {
+    System.getProperties()?.forEach { (k, v) -> println("$k=$v") }
+    println("")
     check(array.size == 2) { "Invalid arguments. 2 expected." }
     assertInfo(array[0], array[1])
     println("PASS")


### PR DESCRIPTION
Closes #107 

<details>
    <summary>raspberry pi 3B output</summary>

```bash
pi@raspberrypi:~ $ uname -m
aarch64
pi@raspberrypi:~ $ file /bin/bash
/bin/bash: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, BuildID[sha1]=f12e6d40fb262ad0037b6ec43162208b76d4da71, for GNU/Linux 3.2.0, stripped
pi@raspberrypi:~ $ java -jar libs/test-info.jar "linux-libc" "armv7"
awt.toolkit=sun.awt.X11.XToolkit
java.specification.version=11
sun.cpu.isalist=
sun.jnu.encoding=UTF-8
java.class.path=libs/test-info.jar
java.vm.vendor=Raspbian
sun.arch.data.model=32
java.vendor.url=Unknown
user.timezone=
os.name=Linux
java.vm.specification.version=11
sun.java.launcher=SUN_STANDARD
user.country=US
sun.boot.library.path=/usr/lib/jvm/java-11-openjdk-armhf/lib
sun.java.command=libs/test-info.jar linux-libc armv7
jdk.debug=release
sun.cpu.endian=little
user.home=/home/pi
user.language=en
java.specification.vendor=Oracle Corporation
java.version.date=2024-04-16
java.home=/usr/lib/jvm/java-11-openjdk-armhf
file.separator=/
line.separator=

java.specification.name=Java Platform API Specification
java.vm.specification.vendor=Oracle Corporation
java.awt.graphicsenv=sun.awt.X11GraphicsEnvironment
sun.management.compiler=HotSpot Tiered Compilers
java.runtime.version=11.0.23+9-post-Raspbian-1deb11u1
user.name=pi
path.separator=:
os.version=6.1.21-v8+
java.runtime.name=OpenJDK Runtime Environment
file.encoding=UTF-8
java.vm.name=OpenJDK Server VM
java.vendor.url.bug=Unknown
java.io.tmpdir=/tmp
java.version=11.0.23
user.dir=/home/pi
os.arch=arm
java.vm.specification.name=Java Virtual Machine Specification
java.awt.printerjob=sun.print.PSPrinterJob
sun.os.patch.level=unknown
java.library.path=/usr/java/packages/lib:/usr/lib/arm-linux-gnueabihf/jni:/lib/arm-linux-gnueabihf:/usr/lib/arm-linux-gnueabihf:/usr/lib/jni:/lib:/usr/lib
java.vm.info=mixed mode
java.vendor=Raspbian
java.vm.version=11.0.23+9-post-Raspbian-1deb11u1
java.specification.maintenance.version=2
sun.arch.abi=
sun.io.unicode.encoding=UnicodeLittle
java.class.version=55.0

PASS
```

</details>